### PR TITLE
Avoid fatal error "Cannot redeclare class OAuthException"

### DIFF
--- a/includes/Twitter/twitteroauth/OAuth.php
+++ b/includes/Twitter/twitteroauth/OAuth.php
@@ -3,8 +3,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if (!class_exists('OAuthException')) {
+	class OAuthException extends Exception {
+	  // pass
+	}
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
Hi Matthew,

Thanks for a great plugin.  I hit the same "Cannot redeclare class OAuthException" error that Sven Schneider mentioned on http://matthewruddy.com/display-tweets-plugin/.  This change fixed it for me; hopefully it'll help other too (and allow me to upgrade the plugin without having to reapply the patch;) ).

Cheers, and thanks again,

Pete
