### PR TITLE
Changed capability requirement to a more suitable capability

### DIFF
--- a/displaytweets.php
+++ b/displaytweets.php
@@ -294,7 +294,7 @@ class DisplayTweets {
         add_options_page(
             __( 'Twitter Feed Settings', 'displaytweets' ),
             __( 'Twitter Feed', 'displaytweets' ),
-            'edit_plugins',
+            'activate_plugins',
             'displaytweets',
             array( $this, 'settings_view' )
         );
@@ -582,7 +582,7 @@ class DisplayTweets {
 
         /** Bail if there are no tweets */
         if ( !$tweets ) {
-            if ( current_user_can( 'edit_plugins' ) )
+            if ( current_user_can( 'activate_plugins' ) )
                 echo '<p style="color: red;">'. __( 'No tweets found. Please make sure your settings are correct.', 'displaytweets' ) .'</p>';
             return;
         }


### PR DESCRIPTION
This allows themes or users that have disabled the plugin and theme editor to use the plugin. Even while logged in as admin, if this plugin is enabled while the editor is disabled you get the following error when trying to view the plugin settings.

`You do not have sufficient permissions to access this page.`

Please see the codex for more information -

http://codex.wordpress.org/Editing_wp-config.php#Disable_the_Plugin_and_Theme_Editor

@MatthewRuddy Thanks for a great plugin BTW.

Credit to @mattbanks for pointing me in the right direction regarding this issue.
