### PR TITLE
Use manage_options instead of edit_plugins capability

### DIFF
--- a/displaytweets.php
+++ b/displaytweets.php
@@ -294,7 +294,7 @@ class DisplayTweets {
         add_options_page(
             __( 'Twitter Feed Settings', 'displaytweets' ),
             __( 'Twitter Feed', 'displaytweets' ),
-            'edit_plugins',
+            'activate_plugins',
             'displaytweets',
             array( $this, 'settings_view' )
         );

--- a/displaytweets.php
+++ b/displaytweets.php
@@ -294,7 +294,7 @@ class DisplayTweets {
         add_options_page(
             __( 'Twitter Feed Settings', 'displaytweets' ),
             __( 'Twitter Feed', 'displaytweets' ),
-            'activate_plugins',
+            'manage_options',
             'displaytweets',
             array( $this, 'settings_view' )
         );

--- a/displaytweets.php
+++ b/displaytweets.php
@@ -53,7 +53,7 @@ class DisplayTweets {
     public static $version = '1.0.3';
 
     /**
-     * How often the tweets are refreshed (in seconds). Defualt is five minutes.
+     * How often the tweets are refreshed (in seconds). Default is five minutes.
      *
      * @since 1.0
      */


### PR DESCRIPTION
According to [the WordPress Codex](http://codex.wordpress.org/Roles_and_Capabilities#edit_plugins), the `edit_plugins` capability is mostly used to determine whether Plugins > Plugin Editor is accessible. On sites that use wp-config.php constants like `DISALLOW_FILE_EDIT` (for instance, all of my production sites), the `edit_plugins` capability is deactivated, meaning I can't configure this plugin without enabling the plugin editor.

This pull request changes the capability to the more sensible manage_options - if the user has the power to change the site title, permalink structure, and other much more destructive changes, they should be able to edit the Twitter configuration.
