### PR TITLE
Fixed Error caused by OAuthException class being redeclared.

### DIFF
--- a/displaytweets.php
+++ b/displaytweets.php
@@ -3,7 +3,7 @@
 /*
     Plugin Name: Display Tweets
     Plugin URI: http://matthewruddy.com/display-tweets-plugin
-    Version: 1.0.3
+    Version: 1.0.4
     Author: Matthew Ruddy
     Author URI: http://matthewruddy.com/
     Description: A rather simple Twitter feed plugin that uses the v1.1 Twitter API.

--- a/includes/Twitter/twitteroauth/OAuth.php
+++ b/includes/Twitter/twitteroauth/OAuth.php
@@ -3,8 +3,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if (!class_exists('OAuthException')) 
+  class OAuthException extends Exception {
+    // pass
+  }
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
Fixes Issue #19 

**Cause:**
PHP Class "OAuthException" being redeclared if it already exists.

**Solution:**
Only declare if it doesn't already exist.

```
if (!class_exists('OAuthException')) 
  class OAuthException extends Exception {
    // pass
  }
}
```

**Resolves the following error message:**
`Cannot redeclare class OAuthException`
